### PR TITLE
Use shell to bypass Windows ENOENT error

### DIFF
--- a/script/postinstall.ts
+++ b/script/postinstall.ts
@@ -69,7 +69,8 @@ async function runNpmCompile(): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const npmProcess = spawn('npm', ['run', 'compile'], {
 			cwd: REPO_ROOT,
-			stdio: 'inherit'
+			stdio: 'inherit',
+			shell: true
 		});
 
 		npmProcess.on('close', (code) => {


### PR DESCRIPTION
To solve this error on Windows:
```
npm error node:internal/child_process:285 
npm error const err = new ErrnoException(exitCode, syscall); 
npm error ^ 
npm error
npm error Error: spawn npm ENOENT 
npm error at ChildProcess._handle.onexit (node:internal/child_process:285:19) 
npm error at onErrorNT (node:internal/child_process:483:16) 
npm error at process.processTicksAndRejections (node:internal/process/task_queues:90:21) { 
npm error errno: -4058, 
npm error code: 'ENOENT', 
npm error syscall: 'spawn npm', 
npm error path: 'npm', 
npm error spawnargs: [ 'run', 'compile' ] 
npm error } 
npm error 
npm error Node.js v22.19.0 
npm error 
npm error code 1 
npm error 
npm error path E:\positron\extensions\positron-copilot-chat 
npm error 
npm error command failed 
npm error 
npm error command C:\WINDOWS\system32\cmd.exe /d /s /c tsx ./script/postinstall.ts
```