### PR TITLE
Copilot: Fixes commit message action conflict with Assistant

### DIFF
--- a/package.json
+++ b/package.json
@@ -3118,7 +3118,7 @@
 			"scm/inputBox": [
 				{
 					"command": "github.copilot.git.generateCommitMessage",
-					"when": "scmProvider == git"
+					"when": "scmProvider == git && github.copilot-chat.activated && (!config.positron.assistant.enable || !config.positron.assistant.gitIntegration.enable)"
 				}
 			],
 			"testing/message/context": [


### PR DESCRIPTION
When Assistant is enabled & git integration is enabled, hide the Copilot commit message generation action button.

Addresses posit-dev/positron#9416