### PR TITLE
Report token usage in Positron format

### DIFF
--- a/src/platform/networking/common/fetch.ts
+++ b/src/platform/networking/common/fetch.ts
@@ -148,6 +148,14 @@ export interface IResponseDelta {
 	copilotConfirmation?: ICopilotConfirmation;
 	thinking?: ThinkingDelta;
 	retryReason?: FilterReason;
+	// --- Start Positron ---
+	usage?: {
+		inputTokens: number;
+		outputTokens: number;
+		cachedTokens: number;
+		providerMetadata?: any;
+	};
+	// --- End Positron ---
 }
 
 export interface FinishedCallback {


### PR DESCRIPTION
Positron Assistant emits token usage as part of the output stream, in a JSON encoded `LanguageModelDataPart` (See https://github.com/posit-dev/positron/pull/9308 for details). This is intended to support token counting in downstream extensions using the LM API, such as Databot.

This commit tweaks copilot chat so that copilot provided LM models emit the same useful token usage data.