### PR TITLE
fix issues with copilot chat compatibility in positron

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
 	"l10n": "./l10n",
 	"enabledApiProposals": [
 		"agentSessionsWorkspace",
-		"chatHooks@1",
 		"extensionsAny",
 		"newSymbolNamesProvider",
 		"interactive",
@@ -115,7 +114,7 @@
 		"mappedEditsProvider",
 		"aiRelatedInformation",
 		"aiSettingsSearch",
-		"chatParticipantAdditions@1",
+		"chatParticipantAdditions",
 		"defaultChatParticipant@4",
 		"contribSourceControlInputBoxMenu",
 		"authLearnMore",

--- a/src/extension/tools/vscode-node/toolsService.ts
+++ b/src/extension/tools/vscode-node/toolsService.ts
@@ -9,6 +9,7 @@ import { IChatEndpoint } from '../../../platform/networking/common/networking';
 import { equals as arraysEqual } from '../../../util/vs/base/common/arrays';
 import { Lazy } from '../../../util/vs/base/common/lazy';
 import { isDisposable } from '../../../util/vs/base/common/lifecycle';
+import { Iterable } from '../../../util/vs/base/common/iterator';
 import { autorunIterableDelta } from '../../../util/vs/base/common/observableInternal';
 import { IInstantiationService } from '../../../util/vs/platform/instantiation/common/instantiation';
 import { getContributedToolName, getToolName, mapContributedToolNamesInSchema, mapContributedToolNamesInString, ToolName } from '../common/toolNames';


### PR DESCRIPTION
- Some experiments to try to address https://github.com/posit-dev/positron/issues/12410

### Missing copilot chat extension

The chat extension is missing because it is incompatible with the APIs in Positron. See these error messages in the devtools:

```
 ERR [/Applications/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat]: This extension is using the API proposals 'chatHooks' and 'chatParticipantAdditions' that are not compatible with the current version of VS Code.
error @ workbench.desktop.main.js:22152
workbench.desktop.main.js:22116 TRACE [LM] Current provider is no longer available, switching to next available copilot
workbench.desktop.main.js:216505 [Extension Host] Ignoring disabled model provider:  copilot (at console.<anonymous> (file:///Applications/Positron.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:99514:14))
```

To resolve this, I:
- removed `chatHooks@1` and unversioned `chatParticipantAdditions@1` in enabledApiProposals
    - `chatHooks` does not exist in Positron's CodeOSS 1.109 base, and `chatParticipantAdditions` is defined without a version number. The versioned proposals were added in upstream v0.38 possibly targeting a pre-release VS Code build which is not quite compatible with our 1.109-based Positron APIs
- When we bring in the copilot chat extension for the 1.110 merge, we can take the changes to chatHooks and chatParticipantAdditions, and Code OSS 1.110 should have the corresponding APIs available then too

### Missing Iterable import

After the above change, sending a message in chat with a github copilot model resulted in an `Iterable is not defined` error, but the fix was just to import it!

<details><summary>Iterable is not defined</summary>

```ts
[error] ReferenceError: Iterable is not defined
    at ToolsService.getEnabledTools (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:563898:40)
    at getAgentTools (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:398402:30)
    at DefaultToolCallingLoop.getAvailableTools (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:397274:19)
    at DefaultToolCallingLoop.runOne (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:371765:26)
    at DefaultToolCallingLoop.run (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:371635:24)
    at DefaultIntentRequestHandler.runWithToolCalling (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:396961:22)
    at DefaultIntentRequestHandler.getResult (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:396797:29)
    at EditIntentRequestHandler.getResult (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:397910:20)
    at ChatParticipantRequestHandler.getResult (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:400302:18)
    at ExtHostChatAgent._requestHandler (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:559744:14)
    at _ExtHostChatAgents2.$invokeAgent (file:///Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:70022:14)
```

</details> 

The import exists upstream so I think maybe just an upstream merge oopsie: https://github.com/microsoft/vscode-copilot-chat/blob/v0.38.2026020408/src/extension/tools/vscode-node/toolsService.ts#L10

### More errors

After adding the import above, still getting errors:

<details><summary>Cannot read properties of undefined (reading 'bind')</summary>

```ts
[error] TypeError: Cannot read properties of undefined (reading 'bind')
    at new CodeBlockTrackingChatResponseStream (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:389479:51)
    at _InstantiationService._createInstance (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:307215:20)
    at _InstantiationService.createInstance (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:307190:21)
    at /Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:396863:74
    at /Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:371808:33
    at Array.forEach (<anonymous>)
    at DefaultToolCallingLoop.runOne (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:371807:40)
    at DefaultToolCallingLoop.run (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:371635:24)
    at DefaultIntentRequestHandler.runWithToolCalling (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:396961:22)
    at DefaultIntentRequestHandler.getResult (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:396797:29)
    at EditIntentRequestHandler.getResult (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:397910:20)
    at ChatParticipantRequestHandler.getResult (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:400302:18)
    at ExtHostChatAgent._requestHandler (/Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/extensions/positron-copilot-chat/dist/extension.js:559744:14)
    at _ExtHostChatAgents2.$invokeAgent (file:///Users/sashimi/dev/VSCode-darwin-arm64/Positron.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:70022:14)

```

</details> 

I think we should either go back to 0.37 of the copilot chat extension, or wait till we merge the copilot chat extension from upstream for 1.110 of upstream Code OSS.